### PR TITLE
Problem: ledger-baker ledger-wallet: Blowing up hydra

### DIFF
--- a/opam2nix-packages.nix
+++ b/opam2nix-packages.nix
@@ -5,7 +5,7 @@ let
 	# For development, set OPAM2NIX_DEVEL to your local
 	# opam2nix repo path
 	devRepo = builtins.getEnv "OPAM2NIX_DEVEL";
-	src = ./opam2nix-packages;
+	src = import ./opam2nix-packages/fetch.nix;
 	opam2nix = fetchgit 	{
 		"url" = "https://github.com/obsidiansystems/opam2nix.git";
 		"fetchSubmodules" = false;

--- a/release.nix
+++ b/release.nix
@@ -4,8 +4,6 @@ let
     inherit (nixpkgs) lib;
   in {
     # inherit (pkgs) bake-central-docker tezos-bake-central tezos-loadtest;
-    ledger-baker = pkgs.callPackage ledger/build.nix { bakingApp = true; };
-    ledger-wallet = pkgs.callPackage ledger/build.nix { bakingApp = false; };
   } // lib.listToAttrs (map (name: lib.nameValuePair name pkgs.tezos.${name}.kit)
                             (builtins.attrNames pkgs.tezos));
 


### PR DESCRIPTION
The clang dependency exceeds maximum allowed output size.

Solution: Disable jobs for now.