### PR TITLE
Problem: latest-nixpkgs: All jobs fail to build topkg

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -10,5 +10,4 @@ let
                             (builtins.attrNames pkgs.tezos));
 
 in mkJobs (import ./nix/nixpkgs.nix {}) // {
-  latest-nixpkgs = mkJobs (import <nixpkgs> {});
 }


### PR DESCRIPTION
    <3>configuring
    <3>building
    <3>Cannot find file topfind.
    <3>Unknown directive `require'.
    <3>builder for '/nix/store/9hmd9nvgr3mvms1hs1xnyx89knii1an9-topkg-0.9.1.drv' failed with exit code 2

Solution: Remove latest-nixpkgs for now.